### PR TITLE
DRAFT: Add mine stats to player sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 coverage.xml
 htmlcov/
 .envrc
+.env

--- a/myning/api/player.py
+++ b/myning/api/player.py
@@ -28,12 +28,20 @@ def sync(score: int):
         "score": score * 100,
     }
 
+    # Convert object to array needed by the API.
+    mine_stats_payload = [{"name": key, **value} for key, value in player.mine_progressions.items()]
+
     if exists:
         url += f"/{player.id}"
         response = requests.patch(url, json=payload, headers=headers)
+        minestats_response = requests.patch(url + "/mine_stats", json=mine_stats_payload, headers=headers)
     else:
         response = requests.post(url, json=payload, headers=headers)
+        # This is a dependent query, the player has to exist first.
+        # If these calls happen in sequence (i.e., response ^ completes first), then it should be fine.
+        minestats_response = requests.patch(url + "/" + player.id + "/mine_stats", json=mine_stats_payload, headers=headers)
 
+    minestats_response.raise_for_status()
     response.raise_for_status()
 
 


### PR DESCRIPTION
Pushes a player's mine progressions as mine_stats. This allows aggregate stat calculations for each mine across all players.

Note: Marking as draft because it's not tested yet, and I'm not sure about the async dependent query when creating the player. The player must exist before their mine stats can be added. I could add mine_stats to player create and patch, but it seems like that might be too big of a request payload for one call.