### PR TITLE
Use print to display rich console markup in check_for_updates

### DIFF
--- a/myning/utilities/git.py
+++ b/myning/utilities/git.py
@@ -39,7 +39,8 @@ def check_for_updates():
     if not changed:
         print("Changelog empty (probably just a patch!)")
 
-    input(f"Press {Formatter.keybind('Enter ↩️')}")
+    print(f"Press {Formatter.keybind('Enter ↩')} to continue", end="")
+    input()
     # So we can restart the game with the updated files
     sys.exit(122)
 


### PR DESCRIPTION
We could also have overridden the input method to use input from rich but this is the only place we're using it