### PR TITLE
Add explanation for having full set upgrade higher than blacksmith level

### DIFF
--- a/myning/chapters/blacksmith.py
+++ b/myning/chapters/blacksmith.py
@@ -80,6 +80,16 @@ class Blacksmith(BaseStore):
             ],
         )
 
+    def confirm_multi_buy(self, items: list[Item]):
+        assert self.buying_option
+        if not items:
+            return PickArgs(
+                message=f"Blacksmith does not have {self.buying_option.name.partition(' ')[2]}; "
+                "you need to upgrade the smith first.",
+                options=[("Shucks", self.pick_buy)],
+            )
+        return super().confirm_multi_buy(items)
+
     def confirm_upgrade(self):
         if self.maxed:
             return PickArgs(


### PR DESCRIPTION
`self.buying_option.name` is `all Hero items`, and partitioned by the first space is `Hero items`. 

e.g. `Blacksmith does not have Hero items; you need to upgrade the smith first.`