### PR TITLE
Improve performance for large lists of inventory items

### DIFF
--- a/myning/tui/army.py
+++ b/myning/tui/army.py
@@ -14,7 +14,6 @@ class ArmyWidget(DataTable):
     def on_mount(self):
         self.border_title = "Army"
         self.show_cursor = False
-        self.update()
 
     def on_click(self):
         self.focus()

--- a/myning/tui/chapter/__init__.py
+++ b/myning/tui/chapter/__init__.py
@@ -58,14 +58,13 @@ class ChapterWidget(ScrollableContainer):
 
     async def on_mount(self):
         if trip.mine and trip.seconds_left != 0:
+            self.update_dashboard()
             self.app.push_screen(
                 MineScreen(),
                 lambda abandoned: self.pick(mine.complete_trip(abandoned)),
             )
         else:
-            self.update_dashboard()
-            args = main_menu.enter() if tutorial.is_complete() else tutorial.enter()
-            self.pick(args)
+            self.pick(main_menu.enter() if tutorial.is_complete() else tutorial.enter())
 
     def on_click(self):
         self.focus()

--- a/myning/tui/inventory.py
+++ b/myning/tui/inventory.py
@@ -15,7 +15,6 @@ class InventoryWidget(DataTable):
         self.add_column("i")
         self.add_column("n", width=32)
         self.add_column("v")
-        self.update()
 
     def on_click(self):
         self.focus()

--- a/myning/tui/inventory.py
+++ b/myning/tui/inventory.py
@@ -7,6 +7,8 @@ player = Player()
 
 
 class InventoryWidget(DataTable):
+    hash = None
+
     def on_mount(self):
         self.show_cursor = False
         self.show_header = False
@@ -19,6 +21,10 @@ class InventoryWidget(DataTable):
         self.focus()
 
     def update(self):
+        inventory_hash = hash(tuple(player.inventory.items))
+        if self.hash == inventory_hash:
+            return
+        self.hash = inventory_hash
         self.border_title = "Inventory"
         self.border_subtitle = (
             f"{len(player.inventory.items)} items "


### PR DESCRIPTION
Benchmarking with ~1500 items, it takes ~0.06 seconds to run `InventoryWidget.update`, which can give the app a laggy feeling because `update` is called on every `pick` (we want any menu selections to reflect in the inventory, e.g. buying/selling items). After adding this logic, it only takes ~0.00003 seconds to compute and compare the hash of the inventory with the previous hash, making the app feel a lot smoother. The expensive logic of clearing the table and adding all the rows back will only happen when there is an actual change. The speed increase will be more noticeable the more items there are.

An alternative solution could be to manually update the inventory only when necessary (such as adding a property to `PickArgs` indicating that inventory should be refreshed, or even targeting the exact rows that should be added or removed from the table), but this seems elegant enough. Targeting rows would be ideal from a TUI perspective, but would be complex at the moment because our data objects are not directly integrated with the TUI widgets. 