### PR TITLE
Render image using chafa.py

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 aiohttp
+chafa.py
+pillow
 pyyaml
-rich-pixels
 textual==0.32.0 # Lock to fix mine screen border bug

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,8 @@ async-timeout==4.0.3
     # via aiohttp
 attrs==23.1.0
     # via aiohttp
+chafa-py==1.1.2
+    # via -r requirements.in
 charset-normalizer==3.2.0
     # via aiohttp
 frozenlist==1.4.0
@@ -37,18 +39,14 @@ multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-pillow==9.5.0
-    # via rich-pixels
+pillow==10.0.0
+    # via -r requirements.in
 pygments==2.16.1
     # via rich
 pyyaml==6.0.1
     # via -r requirements.in
 rich==13.5.2
-    # via
-    #   rich-pixels
-    #   textual
-rich-pixels==2.1.1
-    # via -r requirements.in
+    # via textual
 textual==0.32.0
     # via -r requirements.in
 typing-extensions==4.7.1


### PR DESCRIPTION
This is a lower-priority PR as I'm not completely sold on this; if the image is taking up a large portion of the screen, it will be a little laggy (you can feel responsiveness by pressing tab a few times).  If the image is smaller (e.g. terminal is only half of screen size, or we manually set a limit on the image size), then it's not that bad.

<details>
<summary>Spoiler if you have not completed meteor crater</summary>

|Before |<img src="https://github.com/TheRedPanda17/myning/assets/47578853/b0161a1e-a350-4cf7-9268-0018088b2e6a">|
|-|-|
|After|<img src="https://github.com/TheRedPanda17/myning/assets/47578853/653bbffc-0181-4e68-985d-ae0e4b7b300f">|
|Smaller|<img src="https://github.com/TheRedPanda17/myning/assets/47578853/a477a0e2-6f3b-474a-a799-0222ce642abf">|

</details>