### PR TITLE
Update potential for confirm go back in time

### DIFF
--- a/myning/chapters/time_machine.py
+++ b/myning/chapters/time_machine.py
@@ -84,7 +84,7 @@ def view_potential():
 
 
 @confirm(
-    "\n".join(
+    lambda: "\n".join(
         [
             "Are you sure you want to erase ALL progress and go back in time?",
             f"[{Colors.LOCKED}]You'll lose all your progress and gain the following boosts:",


### PR DESCRIPTION
Bug: If you try to go back in time and look at your potential boost in the subtitle of the confirmation, and without quitting the game go back out and earn some money, then come back to view the potential again, it remains unchanged.

Fix: The `confirm` decorator only created the wrapped function once, so calling `go_back_in_time` repeatedly uses the first `get_potential_standard_boost` call. Changing the message to a callback ensures that the confirmation message will always get re-created. 