### PR TITLE
Show army members' last names in pick options

### DIFF
--- a/myning/chapters/armory.py
+++ b/myning/chapters/armory.py
@@ -13,7 +13,7 @@ inventory = Inventory()
 
 
 def pick_member():
-    member_arrs = [member.abbreviated_arr for member in player.army]
+    member_arrs = [member.pick_arr for member in player.army]
 
     if player.has_upgrade("armory_hints"):
         for i, member_arr in enumerate(member_arrs):
@@ -39,7 +39,7 @@ def pick_member():
     return PickArgs(
         message="Upgrade Your Army Members' Gear",
         options=options,
-        column_titles=player.abbreviated_column_titles,
+        column_titles=player.pick_column_titles,
     )
 
 

--- a/myning/chapters/barracks.py
+++ b/myning/chapters/barracks.py
@@ -26,7 +26,7 @@ inventory = Inventory()
 
 
 def enter():
-    member_arrs = [member.abbreviated_arr for member in player.army]
+    member_arrs = [member.pick_arr for member in player.army]
     handlers = [partial(add_xp, member) for member in player.army]
     options = [
         Option(label, handler, enable_hotkeys=False)
@@ -50,7 +50,7 @@ def enter():
         message="Upgrade Your Allies or Hire More Warriors",
         options=options,
         subtitle=f"You have {player.exp_available} xp to distribute." if player.allies else None,
-        column_titles=player.abbreviated_column_titles,
+        column_titles=player.pick_column_titles,
     )
 
 
@@ -120,14 +120,14 @@ def pick_fire_muscle():
             message="You ain't got nobody to fire!",
             options=[Option("I should have thought of that...", enter)],
         )
-    member_arrs = [member.abbreviated_arr for member in player.allies]
+    member_arrs = [member.pick_arr for member in player.allies]
     handlers = [partial(confirm_fire_muscle, member) for member in player.allies]
     options = [Option(label, handler) for label, handler in zip(member_arrs, handlers)]
     options.append(Option(["", "Go Back"], enter))
     return PickArgs(
         message="Which Ally do you want to fire?",
         options=options,
-        column_titles=player.abbreviated_column_titles,
+        column_titles=player.pick_column_titles,
     )
 
 

--- a/myning/chapters/graveyard.py
+++ b/myning/chapters/graveyard.py
@@ -22,7 +22,7 @@ def enter():
             message="You have no fallen allies to revive.",
             options=[Option("Bummer", main_menu.enter)],
         )
-    member_arrs = [member.abbreviated_arr[:-1] for member in graveyard.fallen_allies]
+    member_arrs = [member.pick_arr[:-1] for member in graveyard.fallen_allies]
     handlers = [partial(action, member) for member in graveyard.fallen_allies]
     options = [Option(label, handler) for label, handler in zip(member_arrs, handlers)]
     return PickArgs(
@@ -31,7 +31,7 @@ def enter():
             *options,
             Option(["", "Go Back"], main_menu.enter),
         ],
-        column_titles=player.abbreviated_column_titles[:-1],
+        column_titles=player.pick_column_titles[:-1],
     )
 
 

--- a/myning/chapters/research_facility.py
+++ b/myning/chapters/research_facility.py
@@ -31,7 +31,7 @@ def enter():
 
 
 def pick_assign():
-    character_arrs = [character.abbreviated_arr for character in player.army[1:]]
+    character_arrs = [character.pick_arr for character in player.army[1:]]
     handlers = [partial(assign, character) for character in player.army[1:]]
     options = [Option(label, handler) for label, handler in zip(character_arrs, handlers)]
     options.append(Option(["", "Go Back"], enter))
@@ -40,7 +40,7 @@ def pick_assign():
         options=options,
         subtitle=f"{len(facility.army)}/{facility.level} researchers assigned\n"
         f"{facility.points_per_hour(macguffin.research_boost):.2f} research points / hr",
-        column_titles=player.abbreviated_column_titles,
+        column_titles=player.pick_column_titles,
     )
 
 
@@ -62,7 +62,7 @@ def pick_remove():
             message="You have no companions currently researching",
             options=[Option("Go Back", enter)],
         )
-    character_arrs = [character.abbreviated_arr for character in facility.army]
+    character_arrs = [character.pick_arr for character in facility.army]
     handlers = [partial(remove, character) for character in facility.army]
     options = [Option(label, handler) for label, handler in zip(character_arrs, handlers)]
     options.append(Option(["", "Go Back"], enter))
@@ -71,7 +71,7 @@ def pick_remove():
         options=options,
         subtitle=f"{len(facility.army)}/{facility.level} researchers assigned\n"
         f"{facility.points_per_hour(macguffin.research_boost):2f} research points / hr",
-        column_titles=player.abbreviated_column_titles,
+        column_titles=player.pick_column_titles,
     )
 
 

--- a/myning/objects/character.py
+++ b/myning/objects/character.py
@@ -256,7 +256,7 @@ class Character(Object):
 
     @classmethod
     @property
-    def column_titles(cls):
+    def army_column_titles(cls):
         return [
             "",
             "Name",
@@ -269,9 +269,9 @@ class Character(Object):
         ]
 
     @property
-    def arr(self):
+    def army_arr(self):
         return [
-            str(self.icon),
+            self.icon,
             self.name.split()[0],
             get_health_bar(self.health, self.max_health),
             Text.from_markup(f"[red1]{self.stats['damage']}[/]", justify="right"),
@@ -286,12 +286,31 @@ class Character(Object):
 
     @classmethod
     @property
-    def abbreviated_column_titles(cls):
-        return [x for i, x in enumerate(cls.column_titles) if i != 2]
+    def pick_column_titles(cls):
+        return [
+            "",
+            "Name",
+            Text(Icons.DAMAGE, justify="center"),
+            Text(Icons.ARMOR, justify="center"),
+            Text(Icons.LEVEL, justify="center"),
+            Text(Icons.XP, justify="center"),
+            Text(Icons.GRAVEYARD, justify="center"),
+        ]
 
     @property
-    def abbreviated_arr(self):
-        return [x for i, x in enumerate(self.arr) if i != 2]
+    def pick_arr(self):
+        return [
+            self.icon,
+            self.name,
+            Text.from_markup(f"[red1]{self.stats['damage']}[/]", justify="right"),
+            Text.from_markup(f"[dodger_blue1]{self.stats['armor']}[/]", justify="right"),
+            Text.from_markup(f"[cyan1]{self.level}[/]", justify="right"),
+            Text.from_markup(
+                f"[magenta1]{self.experience}/{fibonacci(self.level + 1)}[/]",
+                justify="right",
+            ),
+            "🪦" if self.is_ghost else " ",
+        ]
 
     @property
     def equipment_table(self):

--- a/myning/tui/army.py
+++ b/myning/tui/army.py
@@ -51,5 +51,5 @@ class ArmyWidget(DataTable):
             f"{Icons.DAMAGE} [{Colors.WEAPON}]{player.army.total_damage}[/] "
             f"{Icons.ARMOR} [{Colors.ARMOR}]{player.army.total_armor}[/]"
         )
-        self.add_columns(*player.column_titles)
-        self.add_rows(member.arr for member in player.army)
+        self.add_columns(*player.army_column_titles)
+        self.add_rows(member.army_arr for member in player.army)


### PR DESCRIPTION
We used to have last names in pick options but lost them in the tui migration.

There are two main representations of the characters:
- In the army widget use `army_arr`
  - Show only first name, with health bar
- In pick options use `pick_arr`
  - Show full name, no health bar

|Before|After|
|-|-|
|<img width="1512" alt="Screenshot 2023-09-04 at 11 26 39" src="https://github.com/TheRedPanda17/myning/assets/47578853/138d1ba9-5843-4371-8866-d6b9ffcc7bca">|<img width="1512" alt="Screenshot 2023-09-04 at 11 27 01" src="https://github.com/TheRedPanda17/myning/assets/47578853/12562b90-0fa1-4490-97b9-e5702b0d52ef">|
