### PR TITLE
Improve performance for large armies

### DIFF
--- a/myning/objects/army.py
+++ b/myning/objects/army.py
@@ -14,6 +14,23 @@ class Army(UserList[Character]):
         super().__init__(*args, **kwargs)
         self.sort(key=lambda c: (c.__class__.__name__ != "Player", -c.level))
 
+    def __hash__(self):
+        return hash(
+            tuple(
+                (
+                    c.id,
+                    c.icon,
+                    c.name,
+                    c.health,
+                    c.equipment,
+                    c.level,
+                    c.experience,
+                    c.is_ghost,
+                )
+                for c in self
+            )
+        )
+
     def append(self, __object: Character) -> None:
         super().append(__object)
         self.sort(key=lambda c: (c.__class__.__name__ != "Player", -c.level))

--- a/myning/objects/equipment.py
+++ b/myning/objects/equipment.py
@@ -19,6 +19,9 @@ class Equipment:
         else:
             self._slots = slots
 
+    def __hash__(self):
+        return hash(tuple(self._slots.values()))
+
     @property
     def all_items(self):
         return [item for item in self._slots.values() if item]

--- a/myning/tui/army.py
+++ b/myning/tui/army.py
@@ -10,6 +10,7 @@ settings = Settings()
 
 class ArmyWidget(DataTable):
     BINDINGS = [("c", "compact", "Toggle Compact Mode")]
+    hash = None
 
     def on_mount(self):
         self.border_title = "Army"
@@ -23,6 +24,10 @@ class ArmyWidget(DataTable):
         self.update()
 
     def update(self):
+        army_hash = hash((player.army, settings.compact_mode))
+        if self.hash == army_hash:
+            return
+        self.hash = army_hash
         self.clear(columns=True)
         if settings.compact_mode:
             self.compact()


### PR DESCRIPTION
Benchmarks with ~200 members:
- no compact mode: 0.02 seconds
- compact mode: 0.003 seconds
- with hashing: 0.0003 seconds

∴ ~10-100x faster refresh, scaling with number of members

Also before if the army was scrolled down and an option was selected in the chapter, the scroll would be reset because the entire widget was refreshed. This will preserve scroll and only reset when something has changed in the army