### PR TITLE
Add mining minigame

### DIFF
--- a/myning/chapters/base_store.py
+++ b/myning/chapters/base_store.py
@@ -3,7 +3,7 @@ from functools import partial
 
 from rich.text import Text
 
-from myning.chapters import Option, OptionLabel, PickArgs, main_menu
+from myning.chapters import Option, PickArgs, main_menu
 from myning.config import UPGRADES
 from myning.objects.buying_option import BuyingOption
 from myning.objects.equipment import EQUIPMENT_TYPES

--- a/myning/chapters/mine/actions.py
+++ b/myning/chapters/mine/actions.py
@@ -2,10 +2,13 @@ import math
 import random
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from functools import lru_cache
 
 from rich.console import RenderableType
 from rich.table import Table
+from textual.widget import Widget
 
+from myning.chapters.mine.mining_minigame import MiningMinigame, MiningScore
 from myning.objects.army import Army
 from myning.objects.character import Character
 from myning.objects.graveyard import Graveyard
@@ -46,7 +49,7 @@ class Action(ABC):
 
     @property
     @abstractmethod
-    def content(self) -> RenderableType:
+    def content(self) -> RenderableType | Widget:
         pass
 
     @property
@@ -57,23 +60,41 @@ class Action(ABC):
 class MineralAction(Action):
     def __init__(self):
         duration = random.randint(5, trip.seconds_left // 60 + 30)
+        self.game = MiningMinigame(duration)
         super().__init__(duration)
 
     @property
     def content(self):
-        return "\n".join(
-            [
-                f"Mining... ({self.duration} seconds left)\n",
-                "💎  " * (5 - (self.duration - 1) % 5),
-            ]
-        )
+        return self.game
 
     @property
+    @lru_cache(maxsize=1)
     def next(self):
         if not trip.mine:
             return None
-        mineral = generate_mineral(trip.mine.max_item_level, trip.mine.resource)
-        return ItemAction(mineral)
+        minerals = []
+        match self.game.score:
+            case MiningScore.GREEN:
+                minerals.extend(
+                    generate_mineral(trip.mine.max_item_level, trip.mine.resource) for _ in range(2)
+                )
+                return ItemsAction(minerals)
+            case MiningScore.YELLOW:
+                minerals.append(generate_mineral(trip.mine.max_item_level, trip.mine.resource))
+                return ItemsAction(minerals)
+            case MiningScore.ORANGE:
+                return MessageAction(
+                    "[bold orange1]Drat![/]\n\n"
+                    "You've encountered an unexpected pocket of mineral-free rock while mining.\n\n"
+                    "Try a little harder for better prospects!"
+                )
+            case MiningScore.RED:
+                return MessageAction(
+                    "[bold red1]Ouch![/]\n\n"
+                    "You've struck a rocky vein while mining, and take some damage as a result.\n"
+                    "Your progress has been delayed by 10 seconds.\n\n"
+                    "Be more careful with your swings!"
+                )
 
 
 @dataclass
@@ -172,6 +193,7 @@ class CombatAction(Action):
                     FileManager.save(stats)
 
     @property
+    @lru_cache(maxsize=1)
     def next(self):
         self.fight()
         if player.army.defeated:
@@ -255,23 +277,33 @@ class VictoryAction(Action):
         return self if self.duration > 1 else None
 
 
-class ItemAction(Action):
-    def __init__(self, item: Item):
-        self.item = item
-        trip.add_item(item)
-        FileManager.multi_save(item, trip)
+class MessageAction(Action):
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(5)
+
+    @property
+    def content(self):
+        return self.message
+
+
+class ItemsAction(Action):
+    def __init__(self, items: list[Item]):
+        self.items = items
+        trip.add_items(*items)
+        FileManager.multi_save(*items, trip)
         super().__init__(2)
 
     @property
     def content(self):
-        return self.item.battle_new_str
+        return "\n".join(item.battle_new_str for item in self.items)
 
 
-class EquipmentAction(ItemAction):
+class EquipmentAction(ItemsAction):
     def __init__(self):
         assert trip.mine
         equipment = generate_equipment(trip.mine.max_item_level)
-        super().__init__(equipment)
+        super().__init__([equipment])
 
 
 class RecruitAction(Action):

--- a/myning/chapters/mine/mining_minigame.py
+++ b/myning/chapters/mine/mining_minigame.py
@@ -1,0 +1,84 @@
+import random
+from enum import Enum, auto
+from functools import lru_cache
+
+from textual.widgets import Static
+
+
+class MiningScore(Enum):
+    RED = auto()
+    ORANGE = auto()
+    YELLOW = auto()
+    GREEN = auto()
+
+
+COLORS = ["red1", "orange1", "yellow1", "green1", "yellow1", "orange1", "red1"]
+WIDTHS = [1, 1.5, 1.5, 2, 1.5, 1.5, 1]
+assert len(COLORS) == len(WIDTHS)
+assert sum(WIDTHS) == 10
+
+
+class MiningMinigame(Static):
+    def __init__(self, duration: int):
+        super().__init__()
+        self.duration = duration
+        self.segment_width = random.choice([2, 4, 6])
+        self.segment_widths = [int(width * self.segment_width) for width in WIDTHS]
+        self.width = sum(self.segment_widths)
+        self.cursor = random.randint(0, self.width - 1)
+        self.direction = random.choice([-1, 1])
+        self.paused = False
+
+    def on_mount(self):
+        self.tick()
+        self.tick_duration()
+        self.set_interval(1 / 30, self.tick)
+        self.set_interval(1, self.tick_duration)
+
+    def tick(self):
+        if self.paused:
+            return
+        self.cursor = (self.cursor + self.direction) % self.width
+        if self.cursor <= 0 or self.cursor >= self.width - 1:
+            self.direction = -self.direction
+        self.update(
+            "\n".join(
+                [
+                    f"Mining... ({self.duration} seconds left)\n",
+                    "💎  " * (5 - (self.duration - 1) % 5),
+                    "",
+                    "".join(
+                        f"[{color}]{'█' * width}[/]"
+                        for color, width in zip(COLORS, self.segment_widths)
+                    ),
+                    f"{' ' * (self.cursor)}[bold]⛏︎[/]",
+                ]
+            )
+        )
+
+    def tick_duration(self):
+        if self.paused:
+            return
+        self.duration -= 1
+        if self.duration < 0:
+            self.remove()
+
+    def toggle_paused(self):
+        self.display = self.paused
+        self.paused = not self.paused
+
+    @property
+    @lru_cache(maxsize=1)
+    def score(self):
+        self.remove()
+        score = MiningScore.YELLOW
+        if self.duration <= 1:
+            return score
+        acc_width = 0
+        for i, width in enumerate(self.segment_widths):
+            acc_width += width
+            if acc_width >= self.cursor:
+                color = COLORS[i]
+                score = MiningScore[color.removesuffix("1").upper()]
+                break
+        return score

--- a/myning/chapters/mine/mining_minigame.py
+++ b/myning/chapters/mine/mining_minigame.py
@@ -25,7 +25,8 @@ class MiningMinigame(Static):
         self.segment_width = random.choice([2, 4, 6])
         self.segment_widths = [int(width * self.segment_width) for width in WIDTHS]
         self.width = sum(self.segment_widths)
-        self.cursor = random.randint(0, self.width - 1)
+        # start short of edges so direction can flip on next tick if needed
+        self.cursor = random.randint(1, self.width - 2)
         self.direction = random.choice([-1, 1])
         self.paused = False
 

--- a/myning/chapters/mine/screen.py
+++ b/myning/chapters/mine/screen.py
@@ -4,22 +4,25 @@ from typing import Type
 
 from textual.containers import Container, ScrollableContainer
 from textual.screen import Screen
+from textual.widget import Widget
 from textual.widgets import Footer, ProgressBar, Static
 
 from myning.chapters.mine.actions import (
     Action,
     CombatAction,
     EquipmentAction,
-    ItemAction,
+    ItemsAction,
     LoseAllyAction,
     MineralAction,
     RecruitAction,
     VictoryAction,
 )
+from myning.chapters.mine.mining_minigame import MiningScore
 from myning.config import MINE_TICK_LENGTH, TICK_LENGTH, VICTORY_TICK_LENGTH
 from myning.objects.player import Player
 from myning.objects.trip import Trip
 from myning.tui.header import Header
+from myning.utilities.file_manager import FileManager
 from myning.utilities.formatter import Formatter
 from myning.utilities.pick import throttle
 from myning.utilities.tab_title import TabTitle
@@ -76,9 +79,29 @@ class MineScreen(Screen[bool]):
     def action_skip(self):
         if self.abandoning:
             self.abandoning = False
+            if isinstance(self.action, MineralAction):
+                self.action.game.toggle_paused()
+                self.update_screen()
         elif self.should_exit:
             self.exit()
-        elif isinstance(self.action, ItemAction):
+        elif isinstance(self.action, MineralAction):
+            match self.action.game.score:
+                case MiningScore.GREEN:
+                    color = "lime"
+                    trip.seconds_passed(self.action.duration)
+                case MiningScore.YELLOW:
+                    color = "yellow"
+                    trip.seconds_passed(self.action.duration)
+                case MiningScore.ORANGE:
+                    color = "orange"
+                case MiningScore.RED:
+                    color = "red"
+                    trip.seconds_passed(-10)
+                    for member in player.army.living_members:
+                        member.health -= 1
+                    FileManager.multi_save(*player.army)
+            self.skip(color)
+        elif isinstance(self.action, ItemsAction):
             if self.check_skip(TICK_LENGTH):
                 trip.seconds_passed(TICK_LENGTH)
                 self.skip()
@@ -114,7 +137,11 @@ class MineScreen(Screen[bool]):
     def update_screen(self):
         if not trip.mine:
             return
-        self.content.update(self.action.content)
+        if isinstance(self.action.content, Widget):
+            self.content_container.mount(self.action.content, before=0)
+            self.content.update("")
+        else:
+            self.content.update(self.action.content)
         trip_summary = trip.summary
         trip_summary.add_row(
             Icons.HEART, "Army health:", f"{player.army.current_health}/{player.army.total_health}"
@@ -132,19 +159,21 @@ class MineScreen(Screen[bool]):
             self.last_skip_time = current_time
         return skippable
 
-    def skip(self):
+    def skip(self, color: str | None = None):
         self.action = self.next_action
-        self.flash_border()
+        self.flash_border(color)
         self.update_screen()
 
-    def flash_border(self):
-        self.content_container.styles.border = ("round", "lime")
+    def flash_border(self, color: str | None = None):
+        self.content_container.styles.border = ("round", color or "lime")
         self.set_timer(TICK_LENGTH / 2, self.reset_border)
 
     def reset_border(self):
         self.content_container.styles.border = ("round", "dodgerblue")
 
     def confirm_abandon(self):
+        if isinstance(self.action, MineralAction):
+            self.action.game.toggle_paused()
         self.content.update(
             "Are you sure you want to abandon your trip?\n\n"
             f"[bold red1]{Icons.WARNING}  WARNING {Icons.WARNING}[/]\n\n"

--- a/myning/chapters/mine/screen.py
+++ b/myning/chapters/mine/screen.py
@@ -20,6 +20,7 @@ from myning.chapters.mine.actions import (
 from myning.chapters.mine.mining_minigame import MiningScore
 from myning.config import MINE_TICK_LENGTH, TICK_LENGTH, VICTORY_TICK_LENGTH
 from myning.objects.player import Player
+from myning.objects.settings import Settings
 from myning.objects.trip import Trip
 from myning.tui.header import Header
 from myning.utilities.file_manager import FileManager
@@ -29,7 +30,9 @@ from myning.utilities.tab_title import TabTitle
 from myning.utilities.ui import Icons, get_time_str
 
 player = Player()
+settings = Settings()
 trip = Trip()
+
 ACTIONS: dict[str, Type[Action]] = {
     "combat": CombatAction,
     "mineral": MineralAction,
@@ -85,6 +88,14 @@ class MineScreen(Screen[bool]):
         elif self.should_exit:
             self.exit()
         elif isinstance(self.action, MineralAction):
+            if settings.mini_games_disabled:
+                content = str(self.content._renderable)  # pylint: disable=protected-access
+                if "disabled" not in content:
+                    self.content.update(
+                        content
+                        + "\n\nMinigames have been disabled; you can enable them in the settings."
+                    )
+                return
             match self.action.game.score:
                 case MiningScore.GREEN:
                     color = "lime"

--- a/myning/chapters/settings.py
+++ b/myning/chapters/settings.py
@@ -1,7 +1,9 @@
 from myning.chapters import Option, PickArgs, main_menu
 from myning.objects.player import Player
 from myning.objects.settings import Settings
+from myning.utilities.file_manager import FileManager
 from myning.utilities.formatter import Formatter
+from myning.utilities.pick import confirm
 
 player = Player()
 settings = Settings()
@@ -9,6 +11,7 @@ settings = Settings()
 
 def enter():
     options = [
+        Option(["Minigames", f"({settings.mini_games_status})"], toggle_minigames),
         Option(["Compact Mode", f"({settings.compact_status})"], toggle_compact_mode),
     ]
 
@@ -22,8 +25,29 @@ def enter():
     )
 
 
+@confirm(
+    lambda: f"Are you sure you want to {'enable' if settings.mini_games_disabled else 'disable'} "
+    "Minigames?\n"
+    + Formatter.locked(
+        "Minigames allow you to speed up progress, earn more minerals, and have greater "
+        "success in the mines. If you disable them, you will not be able to benefit from the "
+        "bonuses they provide or skip time when there normally would be a mini-game. You can "
+        "always enable and disable them in the settings."
+    ),
+    enter,
+)
+def toggle_minigames():
+    settings.toggle_mini_games()
+    FileManager.save(settings)
+    return PickArgs(
+        message=f"Minigames are now {settings.mini_games_status}",
+        options=[Option("Done.", enter)],
+    )
+
+
 def toggle_compact_mode():
     settings.toggle_compact_mode()
+    FileManager.save(settings)
     return PickArgs(
         message=f"Compact Mode is now {settings.compact_status}",
         options=[Option("Done.", enter)],
@@ -34,45 +58,8 @@ def toggle_compact_mode():
 
 def toggle_sort_order():
     settings.toggle_sort_order()
+    FileManager.save(settings)
     return PickArgs(
         message=f"Sort Order is now {settings.sort_order}",
         options=[Option("Done", enter)],
     )
-
-    # option, _ = pick(
-    #     [
-    #         "Adjust Army Column Height",
-    #         f"Enable/Disable Mini-Games ({settings.mini_games_status})",
-    #         f"Combat Mode ({settings.hard_combat_status})",
-    #         f"Compact Mode ({settings.compact_status})",
-    #         "Exit",
-    #     ],
-    #     "What settings would you like to adjust?",
-    # )
-
-    # if option == "Exit":
-    #     return
-
-    # if "Column Height" in option:
-    #     value = get_int_input(
-    #         "What would you like to change the army column height to?",
-    #         f"Current: {settings.army_columns}",
-    #         5,
-    #         25,
-    #     )
-    #     if value:
-    #         settings.set_army_columns(value)
-
-    # if "Disable Mini-Games" in option:
-    #     settings.toggle_mini_games()
-    #     pick(["Got it"], f"Mini-Games are now {settings.mini_games_status}")
-
-    # if "Combat Mode" in option:
-    #     settings.toggle_hard_combat()
-    #     pick(["Done."], f"Combat Mode is now set to difficulty: {settings.hard_combat_status}")
-
-    # if "Compact Mode" in option:
-    #     settings.toggle_compact_mode()
-    #     pick(["Done."], f"Compact Mode is now {settings.compact_status}")
-
-    # FileManager.save(settings)

--- a/myning/chapters/tutorial.py
+++ b/myning/chapters/tutorial.py
@@ -136,7 +136,11 @@ def learn_mine():
     return narrate(
         [
             f"{jrod.name}: Now we can go mining!",
-            # f"{jrod.name}: There will be some minigames to help you mine or battle better, but you can ignore them without penalty if you want to be AFK. Or you can disable them entirely in the settings after you finish up this here tutorial",
+            f"{jrod.name}: There will be some minigames to help you mine or battle better, and "
+            "your skill will determine the quality of the outcome! Optionally, you can disable "
+            "them entirely in the settings after you finish up this here tutorial, but you would "
+            "not be able to benefit from the bonuses they provide or skip time when there would "
+            "normally be a mini-game",
         ],
         mine.pick_mine,
     )

--- a/myning/tui/army.py
+++ b/myning/tui/army.py
@@ -2,6 +2,7 @@ from textual.widgets import DataTable
 
 from myning.objects.player import Player
 from myning.objects.settings import Settings
+from myning.utilities.file_manager import FileManager
 from myning.utilities.ui import Colors, Icons
 
 player = Player()
@@ -21,6 +22,7 @@ class ArmyWidget(DataTable):
 
     def action_compact(self):
         settings.toggle_compact_mode()
+        FileManager.save(settings)
         self.update()
 
     def update(self):

--- a/myning/utilities/file_manager.py
+++ b/myning/utilities/file_manager.py
@@ -28,7 +28,7 @@ class FileManager:
             os.mkdir(".data/entities")
 
     @classmethod
-    def multi_save(cls, *items):
+    def multi_save(cls, *items: Object):
         for item in items:
             cls.save(item)
 

--- a/tests/chapters/test_mine.py
+++ b/tests/chapters/test_mine.py
@@ -51,7 +51,7 @@ async def test_mining(app: MyningApp, pilot: Pilot, chapter: ChapterWidget):
     assert mineral.name in get_content(app)
 
     # tick after getting mineral goes back to mining
-    await pilot.pause(1)
+    await pilot.pause(4)
     assert "Mining..." in get_content(app)
 
     # complete trip

--- a/tests/chapters/test_mine.py
+++ b/tests/chapters/test_mine.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from textual.pilot import Pilot
 from textual.widgets import Static
 
@@ -14,9 +16,14 @@ player = Player()
 
 def get_content(app: MyningApp):
     # pylint: disable=protected-access
-    return str(app.query_one("MineScreen > ScrollableContainer > Static", Static)._renderable)
+    return "".join(
+        str(w._renderable)
+        for w in app.query("MineScreen > ScrollableContainer > Static")
+        if isinstance(w, Static)
+    )
 
 
+@patch("myning.chapters.mine.mining_minigame.COLORS", ["yellow1"] * 7)
 async def test_mining(app: MyningApp, pilot: Pilot, chapter: ChapterWidget):
     # patch action to always be mineral
     hole_in_the_ground = MINES["Hole in the ground"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ game._state = GameState.READY  # pylint: disable=protected-access
 
 Inventory.initialize()
 inventory = Inventory()
-inventory._items = {}
+inventory._items = {}  # pylint: disable=protected-access
 
 Trip.initialize()
 trip = Trip()
@@ -55,7 +55,7 @@ def mock_save():
 @pytest.fixture(autouse=True)
 def reset_objects():
     player.reset()
-    inventory._items = {}
+    inventory._items = {}  # pylint: disable=protected-access
     trip.clear()
 
 


### PR DESCRIPTION
This should be merged after #48.

![Screenshot 2023-09-05 at 00 12 45](https://github.com/TheRedPanda17/myning/assets/47578853/6e29b2be-9ac5-4dea-8938-98137b988216)

How it works:
- The bar is divided into 5 segments: red, yellow, green, yellow, red
- When enter is pressed determines how much time is skipped
- Green (20% chance): skips remaining duration * 2. This is better than holding enter now, but requires more attention
- Yellow (40% chance): skips remaining duration. This is the same as holding enter now, requiring a little more attention but should be pretty easy to hit either green/yellow
- Red (40% chance): does not skip duration. You would get minerals quicker than someone who was truly afk™ because interacting is more rewarding than not interacting, but there is no other advantage

Ideas for balancing:
- Obtaining minerals has not been changed. We could probably balance it more by adjusting probabilities for mineral quality/quantity (for example maybe red has a chance of not getting anything, or green has a chance to get 2 minerals)
- We can adjust how much time is skipped (e.g. 75% skip for yellow and 150% skip for green, maybe red still skips a little bit)
- We can make higher level mines more challenging by increasing speed

Potential settings:
- We could add a setting to disable the minigame, and make it so that if there is no minigame then pressing enter will do nothing. This can be for either just the mining part or the enter mine in general. 
