### PR TITLE
Add sidebar for army when mining

### DIFF
--- a/myning/chapters/mine/actions.py
+++ b/myning/chapters/mine/actions.py
@@ -79,7 +79,7 @@ class MineralAction(Action):
     def next(self):
         if not trip.mine:
             return None
-        if settings.mini_games_disabled:
+        if settings.mini_games_disabled or self.duration == 0:
             return ItemsAction(
                 [generate_mineral(trip.mine.max_item_level, trip.mine.resource)],
                 "You found a mineral!",

--- a/myning/tui/app.css
+++ b/myning/tui/app.css
@@ -5,8 +5,6 @@ Body {
 
 CurrencyWidget,
 Header,
-HealScreen > Container,
-MineScreen > Container,
 ScrollableContainer {
   border: round dodgerblue;
   border-subtitle-align: left;
@@ -80,8 +78,10 @@ SideBar > DataTable {
 
 HealScreen Container,
 MineScreen Container {
+  border: round dodgerblue;
   height: auto;
   layout: horizontal;
+  padding: 0 0 0 1;
 }
 
 HealScreen Bar,
@@ -89,6 +89,19 @@ HealScreen ProgressBar,
 MineScreen Bar,
 MineScreen ProgressBar {
   width: 1fr;
+}
+
+MineScreen > Horizontal > ScrollableContainer {
+  width: 3fr;
+}
+
+MineScreen Horizontal Vertical {
+  width: 1fr;
+  min-width: 48;
+}
+
+MineScreen Vertical ArmyWidget {
+  height: 1fr;
 }
 
 MineScreen Container > Static {

--- a/tests/chapters/test_mine.py
+++ b/tests/chapters/test_mine.py
@@ -18,7 +18,7 @@ def get_content(app: MyningApp):
     # pylint: disable=protected-access
     return "".join(
         str(w._renderable)
-        for w in app.query("MineScreen > ScrollableContainer > Static")
+        for w in app.query("MineScreen ScrollableContainer Static")
         if isinstance(w, Static)
     )
 


### PR DESCRIPTION
- Sidebar is hidden during combat
- Also made it so that if the minigame wasn't played, it doesn't get scored as yellow

![Screenshot 2023-09-05 at 19 51 55](https://github.com/TheRedPanda17/myning/assets/47578853/21442c6d-0487-451b-b547-b52a3e8473af)

- Compact mode can be toggled by pressing c anytime while mining. In the screenshot the lost health is from testing all the red fails for mining minigame

![Screenshot 2023-09-05 at 20 17 10](https://github.com/TheRedPanda17/myning/assets/47578853/7f02e81a-f02b-4eda-a171-c69056b93457)
