### PR TITLE
Add buyable option to disable purchase confirmation

### DIFF
--- a/myning/changelog.yaml
+++ b/myning/changelog.yaml
@@ -1,6 +1,6 @@
 - name: Disable Purchase Confirmation
-  description: Buyable upgrade to disable the purchase confirmation screen in stores.
-  date: 09-07-2023
+  description: Add option to disable purchase confirmation screen.
+  date: 09-08-2023
 
 - name: Research Species Stats
   description: Ever wanted to know the EXACT stats of a species? It's possible now thanks to research!

--- a/myning/changelog.yaml
+++ b/myning/changelog.yaml
@@ -1,3 +1,7 @@
+- name: Disable Purchase Confirmation
+  description: Buyable upgrade to disable the purchase confirmation screen in stores.
+  date: 09-07-2023
+
 - name: Research Species Stats
   description: Ever wanted to know the EXACT stats of a species? It's possible now thanks to research!
   date: 08-30-23

--- a/myning/chapters/base_store.py
+++ b/myning/chapters/base_store.py
@@ -133,7 +133,6 @@ class BaseStore(ABC):
         )
 
     def buy(self, item: Item):
-        # index = self._items.index(item)
         player.gold -= item.value
         inventory.add_item(item)
         self.remove_item(item)
@@ -147,7 +146,6 @@ class BaseStore(ABC):
             return self.enter()
 
         return self.pick_buy()
-        # return self.select_adjacent_item(index)
 
     def confirm_multi_buy(self, items: list[Item]):
         assert self.buying_option
@@ -169,7 +167,6 @@ class BaseStore(ABC):
         )
 
     def multi_buy(self, items: list[Item]):
-        # last_item_index = self._items.index(items[items.__len__ - 1])
         cost = sum(item.value for item in items)
         player.gold -= cost
         inventory.add_items(items)
@@ -178,7 +175,6 @@ class BaseStore(ABC):
         if settings.purchase_confirmation:
             return self.enter()
         return self.pick_buy()
-        # return self.select_adjacent_item(last_item_index)
 
     def hint_symbol(self, item: Item) -> str:
         if item.type not in EQUIPMENT_TYPES:

--- a/myning/chapters/base_store.py
+++ b/myning/chapters/base_store.py
@@ -117,6 +117,8 @@ class BaseStore(ABC):
                 message="Not enough gold!",
                 options=[Option("Bummer!", self.pick_buy)],
             )
+        if player.has_upgrade("purchase_confirmation") and settings.purchase_confirmation_disabled:
+            return self.buy(item)
         return PickArgs(
             message=f"Are you sure you want to buy {item} for {Formatter.gold(item.value)}?",  # pylint: disable=line-too-long
             options=[
@@ -144,6 +146,8 @@ class BaseStore(ABC):
                 message="Not enough gold!",
                 options=[Option("Bummer!", self.pick_buy)],
             )
+        if player.has_upgrade("purchase_confirmation") and settings.purchase_confirmation_disabled:
+            return self.multi_buy(items)
         return PickArgs(
             message=f"Are you sure you want to buy {self.buying_option.name} for {Formatter.gold(cost)}?",  # pylint: disable=line-too-long
             options=[

--- a/myning/chapters/settings.py
+++ b/myning/chapters/settings.py
@@ -18,6 +18,14 @@ def enter():
     if player.has_upgrade("sort_by_value"):
         options.append(Option(["Sort Order", f"({settings.sort_order})"], toggle_sort_order))
 
+    if player.has_upgrade("purchase_confirmation"):
+        options.append(
+            Option(
+                ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
+                toggle_purchase_confirmation,
+            )
+        )
+
     options.append(Option("Go Back", main_menu.enter))
     return PickArgs(
         message="What settings would you like to adjust?",
@@ -61,5 +69,22 @@ def toggle_sort_order():
     FileManager.save(settings)
     return PickArgs(
         message=f"Sort Order is now {settings.sort_order}",
+        options=[Option("Done", enter)],
+    )
+
+
+@confirm(
+    lambda: f"Are you sure you want to {'enable' if settings.purchase_confirmation_disabled else 'disable'} "
+    "purchase confirmation?\n"
+    + Formatter.locked(
+        "If disabled, you will not be prompted to confirm before purchasing items from a store."
+    ),
+    enter,
+)
+def toggle_purchase_confirmation():
+    settings.toggle_purchase_confirmation()
+    FileManager.save(settings)
+    return PickArgs(
+        message=f"Purchase confirmation is now {settings.purchase_confirmation_status}",
         options=[Option("Done", enter)],
     )

--- a/myning/chapters/settings.py
+++ b/myning/chapters/settings.py
@@ -13,18 +13,14 @@ def enter():
     options = [
         Option(["Minigames", f"({settings.mini_games_status})"], toggle_minigames),
         Option(["Compact Mode", f"({settings.compact_status})"], toggle_compact_mode),
+        Option(
+            ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
+            toggle_purchase_confirmation,
+        ),
     ]
 
     if player.has_upgrade("sort_by_value"):
         options.append(Option(["Sort Order", f"({settings.sort_order})"], toggle_sort_order))
-
-    if player.has_upgrade("purchase_confirmation"):
-        options.append(
-            Option(
-                ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
-                toggle_purchase_confirmation,
-            )
-        )
 
     options.append(Option("Go Back", main_menu.enter))
     return PickArgs(
@@ -74,10 +70,10 @@ def toggle_sort_order():
 
 
 @confirm(
-    lambda: f"Are you sure you want to {'enable' if settings.purchase_confirmation_disabled else 'disable'} "
+    lambda: f"Are you sure you want to {'disable' if settings.purchase_confirmation else 'enable'} "
     "purchase confirmation?\n"
     + Formatter.locked(
-        "If disabled, you will not be prompted to confirm before purchasing items from a store."
+        "If disabled, you will not be prompted to confirm before purchasing items from a store and will stay on the items screen."
     ),
     enter,
 )

--- a/myning/objects/settings.py
+++ b/myning/objects/settings.py
@@ -25,14 +25,14 @@ class Settings(Object, metaclass=Singleton):
         hard_combat_disabled=True,
         compact_mode=False,
         sort_order=SortOrder.TYPE,
-        purchase_confirmation_disabled=False,
+        purchase_confirmation=True,
     ) -> None:
         self.army_columns = army_columns
         self.mini_games_disabled = mini_games_disabled
         self.hard_combat_disabled = hard_combat_disabled
         self.compact_mode = compact_mode
         self.sort_order: SortOrder = sort_order
-        self.purchase_confirmation_disabled = purchase_confirmation_disabled
+        self.purchase_confirmation = purchase_confirmation
 
     @classmethod
     def from_dict(cls, attrs: dict):
@@ -45,7 +45,7 @@ class Settings(Object, metaclass=Singleton):
             "hard_combat_disabled": self.hard_combat_disabled,
             "compact_mode": self.compact_mode,
             "sort_order": self.sort_order,
-            "purchase_confirmation_disabled": self.purchase_confirmation_disabled,
+            "purchase_confirmation": self.purchase_confirmation,
         }
 
     @classmethod
@@ -70,7 +70,7 @@ class Settings(Object, metaclass=Singleton):
         self.sort_order = SortOrder.TYPE if self.sort_order == SortOrder.VALUE else SortOrder.VALUE
 
     def toggle_purchase_confirmation(self):
-        self.purchase_confirmation_disabled = not self.purchase_confirmation_disabled
+        self.purchase_confirmation = not self.purchase_confirmation
 
     @property
     def mini_games_status(self) -> str:
@@ -86,4 +86,4 @@ class Settings(Object, metaclass=Singleton):
 
     @property
     def purchase_confirmation_status(self) -> str:
-        return "disabled" if self.purchase_confirmation_disabled else "enabled"
+        return "enabled" if self.purchase_confirmation else "disabled"

--- a/myning/objects/settings.py
+++ b/myning/objects/settings.py
@@ -25,12 +25,14 @@ class Settings(Object, metaclass=Singleton):
         hard_combat_disabled=True,
         compact_mode=False,
         sort_order=SortOrder.TYPE,
+        purchase_confirmation_disabled=False,
     ) -> None:
         self.army_columns = army_columns
         self.mini_games_disabled = mini_games_disabled
         self.hard_combat_disabled = hard_combat_disabled
         self.compact_mode = compact_mode
         self.sort_order: SortOrder = sort_order
+        self.purchase_confirmation_disabled = purchase_confirmation_disabled
 
     @classmethod
     def from_dict(cls, attrs: dict):
@@ -43,6 +45,7 @@ class Settings(Object, metaclass=Singleton):
             "hard_combat_disabled": self.hard_combat_disabled,
             "compact_mode": self.compact_mode,
             "sort_order": self.sort_order,
+            "purchase_confirmation_disabled": self.purchase_confirmation_disabled,
         }
 
     @classmethod
@@ -66,6 +69,9 @@ class Settings(Object, metaclass=Singleton):
     def toggle_sort_order(self):
         self.sort_order = SortOrder.TYPE if self.sort_order == SortOrder.VALUE else SortOrder.VALUE
 
+    def toggle_purchase_confirmation(self):
+        self.purchase_confirmation_disabled = not self.purchase_confirmation_disabled
+
     @property
     def mini_games_status(self) -> str:
         return "disabled" if self.mini_games_disabled else "enabled"
@@ -77,3 +83,7 @@ class Settings(Object, metaclass=Singleton):
     @property
     def compact_status(self) -> str:
         return "enabled" if self.compact_mode else "disabled"
+
+    @property
+    def purchase_confirmation_status(self) -> str:
+        return "disabled" if self.purchase_confirmation_disabled else "enabled"

--- a/myning/upgrades.yaml
+++ b/myning/upgrades.yaml
@@ -225,12 +225,3 @@ auto_ghost_xp:
     - 1
   costs:
     - 200000
-
-purchase_confirmation:
-  name: Disable Purchase Confirmation Screen
-  descriptions:
-    - Get the option to disable the purchase confirmation screen for stores.
-  values:
-    - 1
-  costs:
-    - 100_000

--- a/myning/upgrades.yaml
+++ b/myning/upgrades.yaml
@@ -225,3 +225,12 @@ auto_ghost_xp:
     - 1
   costs:
     - 200000
+
+purchase_confirmation:
+  name: Disable Purchase Confirmation Screen
+  descriptions:
+    - Get the option to disable the purchase confirmation screen for stores.
+  values:
+    - 1
+  costs:
+    - 100_000


### PR DESCRIPTION
I got frustrated having to confirm every small purchase, so I created an upgrade to buy to let me disable the purchase confirmation screen. Putting it behind a 100k purchase makes it so new players don't accidentally buy massive things until they learn the game. 100k might be too high, not sure how upgrades are valued, but it felt when I could afford 100k is when I started to get annoyed with the confirmation.

This needs tests if you want to require it, but I confirmed it works to purchase the upgrade, and the store behaves correctly when enabled and disabled.