### PR TITLE
Add seed quality research

### DIFF
--- a/myning/changelog.yaml
+++ b/myning/changelog.yaml
@@ -1,6 +1,6 @@
 - name: Disable Purchase Confirmation
-  description: Buyable upgrade to disable the purchase confirmation screen in stores.
-  date: 09-07-2023
+  description: Add option to disable purchase confirmation screen.
+  date: 09-08-2023
 
 - name: Research Species Stats
   description: Ever wanted to know the EXACT stats of a species? It's possible now thanks to research!

--- a/myning/changelog.yaml
+++ b/myning/changelog.yaml
@@ -1,3 +1,7 @@
+- name: Disable Purchase Confirmation
+  description: Buyable upgrade to disable the purchase confirmation screen in stores.
+  date: 09-07-2023
+
 - name: Research Species Stats
   description: Ever wanted to know the EXACT stats of a species? It's possible now thanks to research!
   date: 08-30-23

--- a/myning/chapters/base_store.py
+++ b/myning/chapters/base_store.py
@@ -133,7 +133,6 @@ class BaseStore(ABC):
         )
 
     def buy(self, item: Item):
-        # index = self._items.index(item)
         player.gold -= item.value
         inventory.add_item(item)
         self.remove_item(item)
@@ -147,7 +146,6 @@ class BaseStore(ABC):
             return self.enter()
 
         return self.pick_buy()
-        # return self.select_adjacent_item(index)
 
     def confirm_multi_buy(self, items: list[Item]):
         assert self.buying_option
@@ -169,7 +167,6 @@ class BaseStore(ABC):
         )
 
     def multi_buy(self, items: list[Item]):
-        # last_item_index = self._items.index(items[items.__len__ - 1])
         cost = sum(item.value for item in items)
         player.gold -= cost
         inventory.add_items(items)
@@ -178,7 +175,6 @@ class BaseStore(ABC):
         if settings.purchase_confirmation:
             return self.enter()
         return self.pick_buy()
-        # return self.select_adjacent_item(last_item_index)
 
     def hint_symbol(self, item: Item) -> str:
         if item.type not in EQUIPMENT_TYPES:

--- a/myning/chapters/base_store.py
+++ b/myning/chapters/base_store.py
@@ -117,6 +117,8 @@ class BaseStore(ABC):
                 message="Not enough gold!",
                 options=[Option("Bummer!", self.pick_buy)],
             )
+        if player.has_upgrade("purchase_confirmation") and settings.purchase_confirmation_disabled:
+            return self.buy(item)
         return PickArgs(
             message=f"Are you sure you want to buy {item} for {Formatter.gold(item.value)}?",  # pylint: disable=line-too-long
             options=[
@@ -144,6 +146,8 @@ class BaseStore(ABC):
                 message="Not enough gold!",
                 options=[Option("Bummer!", self.pick_buy)],
             )
+        if player.has_upgrade("purchase_confirmation") and settings.purchase_confirmation_disabled:
+            return self.multi_buy(items)
         return PickArgs(
             message=f"Are you sure you want to buy {self.buying_option.name} for {Formatter.gold(cost)}?",  # pylint: disable=line-too-long
             options=[

--- a/myning/chapters/settings.py
+++ b/myning/chapters/settings.py
@@ -18,6 +18,14 @@ def enter():
     if player.has_upgrade("sort_by_value"):
         options.append(Option(["Sort Order", f"({settings.sort_order})"], toggle_sort_order))
 
+    if player.has_upgrade("purchase_confirmation"):
+        options.append(
+            Option(
+                ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
+                toggle_purchase_confirmation,
+            )
+        )
+
     options.append(Option("Go Back", main_menu.enter))
     return PickArgs(
         message="What settings would you like to adjust?",
@@ -61,5 +69,22 @@ def toggle_sort_order():
     FileManager.save(settings)
     return PickArgs(
         message=f"Sort Order is now {settings.sort_order}",
+        options=[Option("Done", enter)],
+    )
+
+
+@confirm(
+    lambda: f"Are you sure you want to {'enable' if settings.purchase_confirmation_disabled else 'disable'} "
+    "purchase confirmation?\n"
+    + Formatter.locked(
+        "If disabled, you will not be prompted to confirm before purchasing items from a store."
+    ),
+    enter,
+)
+def toggle_purchase_confirmation():
+    settings.toggle_purchase_confirmation()
+    FileManager.save(settings)
+    return PickArgs(
+        message=f"Purchase confirmation is now {settings.purchase_confirmation_status}",
         options=[Option("Done", enter)],
     )

--- a/myning/chapters/settings.py
+++ b/myning/chapters/settings.py
@@ -13,18 +13,14 @@ def enter():
     options = [
         Option(["Minigames", f"({settings.mini_games_status})"], toggle_minigames),
         Option(["Compact Mode", f"({settings.compact_status})"], toggle_compact_mode),
+        Option(
+            ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
+            toggle_purchase_confirmation,
+        ),
     ]
 
     if player.has_upgrade("sort_by_value"):
         options.append(Option(["Sort Order", f"({settings.sort_order})"], toggle_sort_order))
-
-    if player.has_upgrade("purchase_confirmation"):
-        options.append(
-            Option(
-                ["Purchase Confirmation", f"({settings.purchase_confirmation_status})"],
-                toggle_purchase_confirmation,
-            )
-        )
 
     options.append(Option("Go Back", main_menu.enter))
     return PickArgs(
@@ -74,10 +70,10 @@ def toggle_sort_order():
 
 
 @confirm(
-    lambda: f"Are you sure you want to {'enable' if settings.purchase_confirmation_disabled else 'disable'} "
+    lambda: f"Are you sure you want to {'disable' if settings.purchase_confirmation else 'enable'} "
     "purchase confirmation?\n"
     + Formatter.locked(
-        "If disabled, you will not be prompted to confirm before purchasing items from a store."
+        "If disabled, you will not be prompted to confirm before purchasing items from a store and will stay on the items screen."
     ),
     enter,
 )

--- a/myning/objects/settings.py
+++ b/myning/objects/settings.py
@@ -25,14 +25,14 @@ class Settings(Object, metaclass=Singleton):
         hard_combat_disabled=True,
         compact_mode=False,
         sort_order=SortOrder.TYPE,
-        purchase_confirmation_disabled=False,
+        purchase_confirmation=True,
     ) -> None:
         self.army_columns = army_columns
         self.mini_games_disabled = mini_games_disabled
         self.hard_combat_disabled = hard_combat_disabled
         self.compact_mode = compact_mode
         self.sort_order: SortOrder = sort_order
-        self.purchase_confirmation_disabled = purchase_confirmation_disabled
+        self.purchase_confirmation = purchase_confirmation
 
     @classmethod
     def from_dict(cls, attrs: dict):
@@ -45,7 +45,7 @@ class Settings(Object, metaclass=Singleton):
             "hard_combat_disabled": self.hard_combat_disabled,
             "compact_mode": self.compact_mode,
             "sort_order": self.sort_order,
-            "purchase_confirmation_disabled": self.purchase_confirmation_disabled,
+            "purchase_confirmation": self.purchase_confirmation,
         }
 
     @classmethod
@@ -70,7 +70,7 @@ class Settings(Object, metaclass=Singleton):
         self.sort_order = SortOrder.TYPE if self.sort_order == SortOrder.VALUE else SortOrder.VALUE
 
     def toggle_purchase_confirmation(self):
-        self.purchase_confirmation_disabled = not self.purchase_confirmation_disabled
+        self.purchase_confirmation = not self.purchase_confirmation
 
     @property
     def mini_games_status(self) -> str:
@@ -86,4 +86,4 @@ class Settings(Object, metaclass=Singleton):
 
     @property
     def purchase_confirmation_status(self) -> str:
-        return "disabled" if self.purchase_confirmation_disabled else "enabled"
+        return "enabled" if self.purchase_confirmation else "disabled"

--- a/myning/objects/settings.py
+++ b/myning/objects/settings.py
@@ -25,12 +25,14 @@ class Settings(Object, metaclass=Singleton):
         hard_combat_disabled=True,
         compact_mode=False,
         sort_order=SortOrder.TYPE,
+        purchase_confirmation_disabled=False,
     ) -> None:
         self.army_columns = army_columns
         self.mini_games_disabled = mini_games_disabled
         self.hard_combat_disabled = hard_combat_disabled
         self.compact_mode = compact_mode
         self.sort_order: SortOrder = sort_order
+        self.purchase_confirmation_disabled = purchase_confirmation_disabled
 
     @classmethod
     def from_dict(cls, attrs: dict):
@@ -43,6 +45,7 @@ class Settings(Object, metaclass=Singleton):
             "hard_combat_disabled": self.hard_combat_disabled,
             "compact_mode": self.compact_mode,
             "sort_order": self.sort_order,
+            "purchase_confirmation_disabled": self.purchase_confirmation_disabled,
         }
 
     @classmethod
@@ -66,6 +69,9 @@ class Settings(Object, metaclass=Singleton):
     def toggle_sort_order(self):
         self.sort_order = SortOrder.TYPE if self.sort_order == SortOrder.VALUE else SortOrder.VALUE
 
+    def toggle_purchase_confirmation(self):
+        self.purchase_confirmation_disabled = not self.purchase_confirmation_disabled
+
     @property
     def mini_games_status(self) -> str:
         return "disabled" if self.mini_games_disabled else "enabled"
@@ -77,3 +83,7 @@ class Settings(Object, metaclass=Singleton):
     @property
     def compact_status(self) -> str:
         return "enabled" if self.compact_mode else "disabled"
+
+    @property
+    def purchase_confirmation_status(self) -> str:
+        return "disabled" if self.purchase_confirmation_disabled else "enabled"

--- a/myning/research.yaml
+++ b/myning/research.yaml
@@ -156,3 +156,39 @@ time_travel_species:
     - 4500
     - 7500
     - 12500
+
+seed_quality:
+  name: Seed Quality
+  descriptions:
+    - Increase base seed level (10% of garden level)
+    - Increase base seed level (20% of garden level)
+    - Increase base seed level (30% of garden level)
+    - Increase base seed level (40% of garden level)
+    - Increase base seed level (50% of garden level)
+    - Increase base seed level (60% of garden level)
+    - Increase base seed level (70% of garden level)
+    - Increase base seed level (80% of garden level)
+    - Increase base seed level (90% of garden level)
+    - Increase base seed level (100% of garden level)
+  values:
+    - .1
+    - .2
+    - .3
+    - .4
+    - .5
+    - .6
+    - .7
+    - .8
+    - .9
+    - 1
+  costs:
+    - 10
+    - 25
+    - 50
+    - 80
+    - 150
+    - 200
+    - 325
+    - 500
+    - 850
+    - 1200

--- a/myning/strings.yaml
+++ b/myning/strings.yaml
@@ -81,6 +81,66 @@ sizes:
   - Vast
   - Behemoth
   - Big Boi
+  - Enormous
+  - Huge
+  - Immense
+  - Tremendous
+  - Goliath
+  - Humongous
+  - Giant
+  - Grand
+  - Mighty
+  - Herculean
+  - Stupendous
+  - Astronomical
+  - Prodigious
+  - Monumental
+  - Towering
+  - Majestic
+  - King-sized
+  - Oversized
+  - Bulky
+  - Hulking
+  - Brobdingnagian
+  - Whopping
+  - Whalesize
+  - Elephantine
+  - Mountainous
+  - Cyclopean
+  - Godzilla-sized
+  - Colossus
+  - Leviathan
+  - Jupiter-sized
+  - Saturn-sized
+  - Cosmic
+  - Galactic
+  - Universal
+  - Infinite
+  - Boundless
+  - Endless
+  - Limitless
+  - Immortal
+  - Unfathomable
+  - Incomprehensible
+  - Unimaginable
+  - Unthinkable
+  - Unprecedented
+  - Inconceivable
+  - Mind-boggling
+  - Jaw-dropping
+  - Astounding
+  - Staggering
+  - Mind-blowing
+  - Breathtaking
+  - Overwhelming
+  - Phenomenal
+  - Miraculous
+  - Supernatural
+  - Divine
+  - God-like
+  - Giga-berlin
+
+
 
 minerals:
   - Copper Nugget

--- a/myning/upgrades.yaml
+++ b/myning/upgrades.yaml
@@ -225,12 +225,3 @@ auto_ghost_xp:
     - 1
   costs:
     - 200000
-
-purchase_confirmation:
-  name: Disable Purchase Confirmation Screen
-  descriptions:
-    - Get the option to disable the purchase confirmation screen for stores.
-  values:
-    - 1
-  costs:
-    - 100_000

--- a/myning/upgrades.yaml
+++ b/myning/upgrades.yaml
@@ -225,3 +225,12 @@ auto_ghost_xp:
     - 1
   costs:
     - 200000
+
+purchase_confirmation:
+  name: Disable Purchase Confirmation Screen
+  descriptions:
+    - Get the option to disable the purchase confirmation screen for stores.
+  values:
+    - 1
+  costs:
+    - 100_000

--- a/myning/utilities/generators.py
+++ b/myning/utilities/generators.py
@@ -1,18 +1,21 @@
 import math
 import random
 
-from myning.config import SPECIES, STRINGS
+from myning.config import RESEARCH, SPECIES, STRINGS
 from myning.objects.army import Army
 from myning.objects.character import Character, CharacterSpecies
 from myning.objects.equipment import EQUIPMENT_TYPES
 from myning.objects.item import Item, ItemType
 from myning.objects.plant import PLANT_TYPES, Plant
+from myning.objects.research_facility import ResearchFacility
 from myning.utilities import string_generation
 from myning.utilities.rand import (
     get_random_array_item,
     get_random_array_item_and_index,
     get_random_int,
 )
+
+facility = ResearchFacility()
 
 
 def generate_character(
@@ -122,7 +125,10 @@ def generate_reward(max_item_level, entities_killed):
 
 def generate_plant(garden_level: int):
     type = get_random_array_item(PLANT_TYPES)
-    level = get_random_int(1, garden_level + 1)
+    base_level = 1
+    if facility.has_research("seed_quality"):
+        base_level = base_level + math.floor(garden_level * RESEARCH["seed_quality"].player_value)
+    level = get_random_int(base_level, garden_level + 1)
     value = 10 * level
     adjective = STRINGS["sizes"][level]
     name = f"{adjective} {type.value} seed"


### PR DESCRIPTION
Adds research option to improve the base level of seeds generated in the seed store. The purpose is to have more high-quality seeds available for the "buy all seeds" upgrade. This is based on earlier conversations about why I wanted the "skip confirmation" setting.

It made the most sense to me to put this in research, since it's a similar upgrade scale & pattern to other research tasks. I'm not sure the balance of research cost to garden revenue, so definitely open to feedback. I pulled the scale from a similar research item.

I played around with the balance of percentage scale, and it made sense to keep that with the linear 10% per level, since it's not until the last few research levels that the upgrade sees big wins. We could do a log scale or something similar, where the higher levels have diminishing returns. But at the end of the day, I want the seeds in the store to match my garden level because I only want the good stuff.